### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 Developed by Fábio Ferreira ([@fabiomlferreira](https://x.com/fabiomlferreira)).
 Check out [dotcursorrules.com](https://dotcursorrules.com/) for more AI development enhancements.
 
+<a href="https://glama.ai/mcp/servers/@noopstudios/interactive-feedback-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@noopstudios/interactive-feedback-mcp/badge" alt="Interactive Feedback MCP server" />
+</a>
+
 Simple [MCP Server](https://modelcontextprotocol.io/) to enable a human-in-the-loop workflow in AI-assisted development tools like [Cursor](https://www.cursor.com). This server allows you to run commands, view their output, and provide textual feedback directly to the AI. It is also compatible with [Cline](https://cline.bot) and [Windsurf](https://windsurf.com).
 
 ![Interactive Feedback UI - Main View](https://github.com/noopstudios/interactive-feedback-mcp/blob/main/.github/interactive_feedback_1.jpg?raw=true)


### PR DESCRIPTION
This PR adds a badge for the [Interactive Feedback MCP](https://glama.ai/mcp/servers/@noopstudios/interactive-feedback-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@noopstudios/interactive-feedback-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@noopstudios/interactive-feedback-mcp/badge" alt="Interactive Feedback MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.