### PR TITLE
docs: improve prompt guidance for continuous feedback loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For the best results, add the following to your custom prompt in your AI assista
 
 > Whenever you want to ask a question, always call the MCP `interactive_feedback`.  
 > Whenever you’re about to complete a user request, call the MCP `interactive_feedback` instead of simply ending the process.
-> If the feedback is empty you can end the request and don't call the mcp in loop.
+> Keep calling MCP until the user’s feedback is empty, then end the request.
 
 This will ensure your AI assistant uses this MCP server to request user feedback before marking the task as completed.
 


### PR DESCRIPTION
Enhance the prompt instructions to explicitly direct AI assistants to continue calling the MCP until user feedback is empty, ensuring a more consistent interactive feedback experience in Cursor and other tools.

This change clarifies the looping behavior and improves the overall user-AI interaction workflow.