### PR TITLE
Fix: Resolve emoji input crash in Qt feedback UI

### DIFF
--- a/feedback_ui.py
+++ b/feedback_ui.py
@@ -205,6 +205,19 @@ class FeedbackTextEdit(QTextEdit):
                 parent._submit_feedback()
         else:
             super().keyPressEvent(event)
+            
+    def insertFromMimeData(self, source):
+        """Override to handle paste operations safely, especially with emoji"""
+        try:
+            if source.hasText():
+                text = source.text()
+                cursor = self.textCursor()
+                cursor.insertText(text)
+            else:
+                super().insertFromMimeData(source)
+        except Exception:
+            # If paste fails, silently ignore to prevent crash
+            pass
 
 class LogSignals(QObject):
     append_log = Signal(str)


### PR DESCRIPTION
**Problem:**
Pasting emojis or certain Unicode characters into the feedback input field caused the UI to crash.
**Solution:**
Overrode insertFromMimeData in FeedbackTextEdit to safely handle text pasting. Exceptions during pasting (e.g., due to emojis) are now caught and silently ignored, preventing the application from crashing.
**Impact:**
* Resolves UI crashes when pasting emojis.
* No breaking changes.
* Application remains stable during Unicode paste operations.
Fixes: https://github.com/noopstudios/interactive-feedback-mcp/issues/36#issue-3167137144